### PR TITLE
Fix home banner: anchor labels at top, taller on mobile

### DIFF
--- a/apps/site/src/pages/[locale]/index.astro
+++ b/apps/site/src/pages/[locale]/index.astro
@@ -159,6 +159,7 @@ function calMonth(date: Date): string {
     width: 100%;
     height: 100%;
     object-fit: cover;
+    object-position: center top;
     display: block;
   }
   .hero-body {

--- a/apps/site/src/pages/[locale]/index.astro
+++ b/apps/site/src/pages/[locale]/index.astro
@@ -210,16 +210,20 @@ function calMonth(date: Date): string {
   }
 
   @media (max-width: 600px) {
+    .banner {
+      /* taller on mobile so labels stay clear of the avatar overlap below */
+      aspect-ratio: 1400 / 420;
+    }
     .hero-body {
       flex-direction: column;
       gap: var(--space-2);
     }
     .avatar-wrap {
-      margin-top: -64px;
+      margin-top: -52px;
     }
     .avatar {
-      width: 140px;
-      height: 140px;
+      width: 132px;
+      height: 132px;
       border-width: 4px;
     }
     .hero-text {


### PR DESCRIPTION
Two related fixes for the home banner so the meme labels stay readable.

**Desktop:** banner is taller than the container's aspect ratio, so \`object-fit: cover\` was trimming ~45px each off top and bottom. The labels sit at the top of the meme, so default center alignment ate into "Apocalypse" / "Having to go to work". Switched \`object-position\` to \`center top\` — labels intact, only the bottom (mostly arrow tail + blank space) gets cropped.

**Mobile:** at narrow widths the desktop aspect ratio (1400/260) collapses the banner to ~72px tall, while the avatar's -64px overlap covered basically all of it — so the labels were hidden behind the circular avatar. Bumped the mobile banner aspect to 1400/420 (~110px tall at 390px viewport), tightened the avatar overlap to -52px, and dropped the avatar a notch (140 → 132px). ~58px of clean banner visible above the avatar — enough for both labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)