### PR TITLE
Show all blog posts on both /en/ and /ua/ blog index

### DIFF
--- a/apps/site/src/lib/content.ts
+++ b/apps/site/src/lib/content.ts
@@ -20,11 +20,16 @@ export function postSlug(entry: PostEntry): string {
   return entry.slug.split('/').pop() ?? entry.slug;
 }
 
-export async function getPostsByLocale(locale: Locale): Promise<PostEntry[]> {
+/**
+ * All published posts across both locales, newest first. Locale-agnostic on
+ * purpose: the same blog list is shown under /en/blog/ and /ua/blog/ so a
+ * Ukrainian visitor doesn't land on an empty page just because nothing has
+ * been translated yet. Per-post pages still respect the locale and surface
+ * a "Translation pending" banner when a post is shown in the other shell.
+ */
+export async function getPosts(): Promise<PostEntry[]> {
   const all = await getCollection('posts', isPublished);
-  return all
-    .filter((p) => p.data.language === locale)
-    .sort((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime());
+  return all.sort((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime());
 }
 
 export async function getPostByCanonicalSlug(canonicalSlug: string, locale: Locale): Promise<PostEntry | undefined> {

--- a/apps/site/src/pages/[locale]/blog/index.astro
+++ b/apps/site/src/pages/[locale]/blog/index.astro
@@ -2,7 +2,7 @@
 import { LOCALES, t, type Locale } from '@lib/i18n';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import PostCard from '@components/PostCard.astro';
-import { getPostsByLocale } from '@lib/content';
+import { getPosts } from '@lib/content';
 
 export async function getStaticPaths() {
   return LOCALES.map((locale) => ({ params: { locale } }));
@@ -10,7 +10,7 @@ export async function getStaticPaths() {
 
 const locale = Astro.params.locale as Locale;
 const strings = t(locale);
-const posts = await getPostsByLocale(locale);
+const posts = await getPosts();
 ---
 
 <BaseLayout locale={locale} title={strings.nav.blog} alternatePath="blog">

--- a/apps/site/src/pages/[locale]/rss.xml.ts
+++ b/apps/site/src/pages/[locale]/rss.xml.ts
@@ -1,7 +1,7 @@
 import rss from '@astrojs/rss';
 import type { APIRoute } from 'astro';
 import { LOCALES, t, bcp47Locale, type Locale } from '@lib/i18n';
-import { getPostsByLocale, postSlug } from '@lib/content';
+import { getPosts, postSlug } from '@lib/content';
 
 export async function getStaticPaths() {
   return LOCALES.map((locale) => ({ params: { locale } }));
@@ -10,7 +10,7 @@ export async function getStaticPaths() {
 export const GET: APIRoute = async ({ params, site }) => {
   const locale = params.locale as Locale;
   const strings = t(locale);
-  const posts = await getPostsByLocale(locale);
+  const posts = await getPosts();
   return rss({
     title: `${strings.site.title} (${locale.toUpperCase()})`,
     description: strings.site.tagline,


### PR DESCRIPTION
The blog index was filtered by locale, so /ua/blog/ rendered an empty state because none of the imported posts have language: "ua" yet. Talks already show on both locales — bringing blog into line with that.

Replaced getPostsByLocale with locale-agnostic getPosts() that returns all published posts newest-first. Both the blog index and the RSS feed now use it.

Per-post pages still respect the locale shell — visiting /ua/blog/<en-only-slug>/ shows the English body wrapped in the UA chrome with the existing TranslationPendingBanner. So the visitor reads the actual content with a clear note that a Ukrainian translation isn't ready yet.

Verified locally: /en/blog/ and /ua/blog/ both list 13 posts now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)