### PR TITLE
Add JEEConf 2015 talk: Building DSLs with Groovy

### DIFF
--- a/apps/site/src/content/talks/groovy-dsls-jeeconf-2015.md
+++ b/apps/site/src/content/talks/groovy-dsls-jeeconf-2015.md
@@ -1,0 +1,15 @@
+---
+title: "Building domain-specific languages with Groovy"
+event: "JEEConf 2015, Kyiv"
+eventUrl: "https://jeeconf.com/speaker/yaroslav-yermilov/"
+date: 2015-05-23
+abstract: |
+  Domain-specific languages (aka DSLs) brings their creators to the new level of abstractions power. They indulge two primary desires of each developer: to play with challenging and interesting problems and to make future tasks easier and more pleasant to work with. What usually stops everyone from implementing really nice DSL is either poorness or complexity of instruments for their creation.
+
+  Groovy is modern JVM language which features makes it first choice for simple and enjoyable DSLs implementing. In this talk, we will look at the instruments that Groovy provide for DSL builders and use it for creating our own DSL. We will cover features ranging from what Groovy can suggest for standard Java developer to transform his ugly Java DSL into something acceptable in 5 minutes to advanced features like Metaobject protocol and AST transformations.
+repoUrl: "https://github.com/yermilov/groovy-dsl"
+tags:
+  - groovy
+  - jvm
+  - dsl
+---


### PR DESCRIPTION
Found on the JEEConf speaker archive at jeeconf.com/speaker/yaroslav-yermilov/.

Talk was in Russian, so following the established pattern: language field omitted, no video link. Slides weren't published, so just the GitHub repo (github.com/yermilov/groovy-dsl) is linked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)