### PR TITLE
Add JEEConf 2019 talk + embed SlideShare slides

### DIFF
--- a/apps/site/src/content/talks/groovy-dsls-jeeconf-2015.md
+++ b/apps/site/src/content/talks/groovy-dsls-jeeconf-2015.md
@@ -7,6 +7,7 @@ abstract: |
   Domain-specific languages (aka DSLs) brings their creators to the new level of abstractions power. They indulge two primary desires of each developer: to play with challenging and interesting problems and to make future tasks easier and more pleasant to work with. What usually stops everyone from implementing really nice DSL is either poorness or complexity of instruments for their creation.
 
   Groovy is modern JVM language which features makes it first choice for simple and enjoyable DSLs implementing. In this talk, we will look at the instruments that Groovy provide for DSL builders and use it for creating our own DSL. We will cover features ranging from what Groovy can suggest for standard Java developer to transform his ugly Java DSL into something acceptable in 5 minutes to advanced features like Metaobject protocol and AST transformations.
+slidesUrl: "https://www.slideshare.net/slideshow/groovy-dsl-48630799/48630799"
 repoUrl: "https://github.com/yermilov/groovy-dsl"
 tags:
   - groovy

--- a/apps/site/src/content/talks/string-processing-jeeconf-2019.md
+++ b/apps/site/src/content/talks/string-processing-jeeconf-2019.md
@@ -1,0 +1,22 @@
+---
+title: "String and Text Processing in Java on a Scale"
+event: "JEEConf 2019, Kyiv"
+eventUrl: "https://jeeconf.com/program/string-and-text-processing-in-java-on-a-scale/"
+date: 2019-05-17
+abstract: |
+  Our Java applications handle millions of strings per second. We work with different platforms, including mobile. On a scale, even rare things happen. You can bet that eventually, an innocent text will crash your server… or the whole cluster. Over the years we have tried many performance tricks. Or should we call it premature optimizations?
+
+  In this talk, we'll share what we have learned about heavy string processing in Java:
+
+  - Upgrading to Java 11. New java.util.String — expectations and reality
+  - JVM string optimizations and hacks — which ones do you need?
+  - Tips for fast and robust regular expressions
+  - Emoji that make you cry
+  - Services in other languages — what is the true length of my Java string?
+slidesUrl: "https://www.slideshare.net/slideshow/string-and-text-processing-in-java-on-a-scale/145296175"
+tags:
+  - java
+  - performance
+  - jvm
+  - grammarly
+---

--- a/apps/site/src/lib/i18n.ts
+++ b/apps/site/src/lib/i18n.ts
@@ -44,6 +44,7 @@ export interface Strings {
     nextUp: string;
     past: string;
     recording: string;
+    slides: string;
     photos: string;
     backToTalks: string;
   };
@@ -93,6 +94,7 @@ const STRINGS: Record<Locale, Strings> = {
       nextUp: 'Next up',
       past: 'Past',
       recording: 'Recording',
+      slides: 'Slides',
       photos: 'Photos',
       backToTalks: '← Back to talks',
     },
@@ -140,6 +142,7 @@ const STRINGS: Record<Locale, Strings> = {
       nextUp: 'Далі',
       past: 'Минулі',
       recording: 'Запис',
+      slides: 'Слайди',
       photos: 'Фото',
       backToTalks: '← До доповідей',
     },

--- a/apps/site/src/pages/[locale]/talks/[slug].astro
+++ b/apps/site/src/pages/[locale]/talks/[slug].astro
@@ -58,6 +58,27 @@ const embedUrl = yt
   ? `https://www.youtube-nocookie.com/embed/${yt.id}${yt.start ? `?start=${yt.start}` : ''}`
   : null;
 
+/**
+ * Detect SlideShare canonical URLs and convert to an embed-able URL.
+ * Canonical: https://www.slideshare.net/slideshow/<slug>/<numeric-id>
+ * Embed:     https://www.slideshare.net/slideshow/embed_code/<numeric-id>
+ *            (302s to /embed_code/key/<key>; the browser follows the redirect)
+ */
+function parseSlideShare(url: string | undefined): string | null {
+  if (!url) return null;
+  try {
+    const u = new URL(url);
+    if (!u.hostname.endsWith('slideshare.net')) return null;
+    const m = u.pathname.match(/\/slideshow\/[^/]+\/(\d+)\/?$/);
+    if (m && m[1]) return `https://www.slideshare.net/slideshow/embed_code/${m[1]}`;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+const slidesEmbedUrl = parseSlideShare(talk.data.slidesUrl);
+
 const paragraphs = talk.data.abstract.split(/\n\n+/);
 ---
 
@@ -104,6 +125,20 @@ const paragraphs = talk.data.abstract.split(/\n\n+/);
               title={talk.data.title}
               loading="lazy"
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowfullscreen
+            ></iframe>
+          </div>
+        </section>
+      )}
+
+      {slidesEmbedUrl && (
+        <section class="block">
+          <p class="workbench section-label">▸ {strings.talks.slides}</p>
+          <div class="slides">
+            <iframe
+              src={slidesEmbedUrl}
+              title={`${talk.data.title} — slides`}
+              loading="lazy"
               allowfullscreen
             ></iframe>
           </div>
@@ -210,6 +245,19 @@ const paragraphs = talk.data.abstract.split(/\n\n+/);
     background: #000;
   }
   .video iframe {
+    width: 100%;
+    height: 100%;
+    border: 0;
+    display: block;
+  }
+
+  .slides {
+    aspect-ratio: 4 / 3;
+    width: 100%;
+    border: 1px solid var(--rule);
+    background: var(--bg-elevated);
+  }
+  .slides iframe {
     width: 100%;
     height: 100%;
     border: 0;


### PR DESCRIPTION
## Summary

- **JEEConf 2019**: "String and Text Processing in Java on a Scale" added at /en/talks/string-processing-jeeconf-2019/. Same pattern as other Russian-language talks — language field omitted, no video link, slides via SlideShare.
- **SlideShare embedding on detail pages**: when slidesUrl matches the canonical pattern \`slideshare.net/slideshow/<slug>/<id>\`, the talk detail page now renders a \`▸ Slides\` section with an iframe pointing at \`slideshare.net/slideshow/embed_code/<id>\`. SlideShare 302s to the key-based URL; browsers follow transparently. 4/3 aspect ratio with a 1px rule border, matching the existing recording iframe style.

Four existing talks now embed slides on their detail pages:
- groovy-dsls-jeeconf-2015 (also added slidesUrl)
- it-scales-fwdays-2018
- it-scales-devoxx-2018
- string-processing-jeeconf-2019 (new)

i18n: added talks.slides ("Slides" / "Слайди") matching the existing talks.recording naming pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)