### PR TITLE
Fix translation-pending banner for UA-only posts

### DIFF
--- a/apps/site/src/components/TranslationPendingBanner.astro
+++ b/apps/site/src/components/TranslationPendingBanner.astro
@@ -4,14 +4,21 @@ import { t } from '@lib/i18n';
 
 interface Props {
   locale: Locale;
+  /** Language the original post body is written in. Drives banner copy
+      so we don't tell visitors of a UA-only post that it's an "English original". */
+  sourceLocale: Locale;
 }
-const { locale } = Astro.props;
+const { locale, sourceLocale } = Astro.props;
 const strings = t(locale);
+const message =
+  sourceLocale === 'en'
+    ? strings.labels.translationPendingFromEn
+    : strings.labels.translationPendingFromUa;
 ---
 
 <aside class="translation-pending" role="note">
   <span class="dot" aria-hidden="true"></span>
-  <p>{strings.labels.translationPending}</p>
+  <p>{message}</p>
 </aside>
 
 <style>

--- a/apps/site/src/layouts/PostLayout.astro
+++ b/apps/site/src/layouts/PostLayout.astro
@@ -16,6 +16,8 @@ interface Props {
   alternateMissing?: boolean;
   /** the original-language post body is being shown as a fallback */
   translationPending?: boolean;
+  /** language of the post body that is actually being shown */
+  sourceLocale: Locale;
 }
 
 const {
@@ -29,6 +31,7 @@ const {
   alternatePath,
   alternateMissing = false,
   translationPending = false,
+  sourceLocale,
 } = Astro.props;
 
 const strings = t(locale);
@@ -44,7 +47,7 @@ const fmt = new Intl.DateTimeFormat(bcp47Locale(locale), { dateStyle: 'long' });
 >
   <article class="page-frame post" data-pagefind-body>
     <header class="post-header prose-column">
-      {translationPending && <TranslationPendingBanner locale={locale} />}
+      {translationPending && <TranslationPendingBanner locale={locale} sourceLocale={sourceLocale} />}
       <p class="workbench post-meta">
         <time datetime={publishedAt.toISOString()}>{fmt.format(publishedAt)}</time>
         {updatedAt && (

--- a/apps/site/src/lib/i18n.ts
+++ b/apps/site/src/lib/i18n.ts
@@ -59,7 +59,8 @@ export interface Strings {
     backToHome: string;
     search: string;
     controls: string;
-    translationPending: string;
+    translationPendingFromEn: string;
+    translationPendingFromUa: string;
     video: string;
     slides: string;
     repo: string;
@@ -111,7 +112,8 @@ const STRINGS: Record<Locale, Strings> = {
       backToHome: 'Back to home',
       search: 'Search',
       controls: 'Controls',
-      translationPending: 'This post is not yet translated to Ukrainian. Showing the English original.',
+      translationPendingFromEn: 'This post is not yet translated to Ukrainian. Showing the English original.',
+      translationPendingFromUa: 'This post is not yet translated to English. Showing the Ukrainian original.',
       video: 'video',
       slides: 'slides',
       repo: 'repo',
@@ -161,7 +163,8 @@ const STRINGS: Record<Locale, Strings> = {
       backToHome: 'На головну',
       search: 'Пошук',
       controls: 'Керування',
-      translationPending: 'Цей текст ще не перекладено українською. Показано англійський оригінал.',
+      translationPendingFromEn: 'Цей текст ще не перекладено українською. Показано англійський оригінал.',
+      translationPendingFromUa: 'Цей текст ще не перекладено англійською. Показано український оригінал.',
       video: 'відео',
       slides: 'слайди',
       repo: 'репо',

--- a/apps/site/src/pages/[locale]/blog/[slug].astro
+++ b/apps/site/src/pages/[locale]/blog/[slug].astro
@@ -52,7 +52,7 @@ export async function getStaticPaths() {
   return paths;
 }
 
-const { post, translationPending, alternatePath, alternateMissing } = Astro.props;
+const { post, sourceLocale, translationPending, alternatePath, alternateMissing } = Astro.props;
 const locale = Astro.params.locale as Locale;
 const { Content } = await post.render();
 ---
@@ -68,6 +68,7 @@ const { Content } = await post.render();
   alternatePath={alternatePath}
   alternateMissing={alternateMissing}
   translationPending={translationPending}
+  sourceLocale={sourceLocale}
 >
   <Content />
 </PostLayout>


### PR DESCRIPTION
## Summary
The translation-pending banner copy was hard-coded for the EN→UA direction. The newly-imported [\`ua/ai-coding-in-education\`](https://yermilov.github.io/en/blog/ai-coding-in-education/) post is UA-only, so visiting its \`/en/\` URL falls back to the Ukrainian body — but the banner wrongly says \"This post is not yet translated to Ukrainian. Showing the English original.\"

This splits \`labels.translationPending\` into two strings keyed by the post's source locale, threads \`sourceLocale\` through \`PostLayout\`, and picks the right one in \`TranslationPendingBanner\`.

| URL | Post body | Banner |
|---|---|---|
| \`/en/\` EN-only | EN | none |
| \`/en/\` UA-only (fallback) | UA | \"This post is not yet translated to English. Showing the Ukrainian original.\" |
| \`/ua/\` UA-only | UA | none |
| \`/ua/\` EN-only (fallback) | EN | \"Цей текст ще не перекладено українською. Показано англійський оригінал.\" |

## Test plan
- [x] \`pnpm --filter site typecheck\` clean (32 files, 0/0/0)
- [x] Visually verified all four states above in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)