### PR TITLE
Drop the lede paragraph from individual post pages

### DIFF
--- a/apps/site/src/layouts/PostLayout.astro
+++ b/apps/site/src/layouts/PostLayout.astro
@@ -55,7 +55,6 @@ const fmt = new Intl.DateTimeFormat(bcp47Locale(locale), { dateStyle: 'long' });
         )}
       </p>
       <h1>{title}</h1>
-      {description && <p class="lede">{description}</p>}
     </header>
     {coverImage && (
       <figure class="post-cover prose-column">
@@ -88,11 +87,6 @@ const fmt = new Intl.DateTimeFormat(bcp47Locale(locale), { dateStyle: 'long' });
     display: flex;
     gap: 0.5rem;
     flex-wrap: wrap;
-  }
-  .lede {
-    font-size: 1.2rem;
-    color: var(--ink-muted);
-    margin-top: var(--space-2);
   }
   .post-cover {
     margin: 0 0 var(--space-4);


### PR DESCRIPTION
## Summary
The post detail page previously echoed the post's \`summary\` as a muted lede paragraph between the H1 and the body. The blog index already shows the same summary under each title — repeating it on the detail page just delayed the actual content.

This drops the lede markup and its CSS from \`PostLayout.astro\`. The \`description\` prop still flows into \`<meta name=\"description\">\` and OG tags via \`BaseLayout\`, so SEO and link previews are unchanged.

## Test plan
- [x] \`pnpm --filter site typecheck\` clean (32 files, 0/0/0)
- [x] Visually verified \`/ua/blog/ai-coding-in-education/\` — date → title → body, no repeating intro
- [x] Visually verified \`/ua/blog/\` — summaries still render under each title

🤖 Generated with [Claude Code](https://claude.com/claude-code)