### PR TITLE
Restore list bullets in post body (Tailwind Preflight regression)

### DIFF
--- a/apps/site/src/layouts/PostLayout.astro
+++ b/apps/site/src/layouts/PostLayout.astro
@@ -108,6 +108,33 @@ const fmt = new Intl.DateTimeFormat(bcp47Locale(locale), { dateStyle: 'long' });
     border-radius: 6px;
     border: 1px solid var(--rule);
   }
+  /* Restore default list bullets/numbers — Tailwind Preflight strips them
+     globally and we don't use the typography plugin, so prose lists need
+     their own scoped re-enable. */
+  .post-body :global(ul) {
+    list-style: disc outside;
+    padding-inline-start: 1.4rem;
+  }
+  .post-body :global(ol) {
+    list-style: decimal outside;
+    padding-inline-start: 1.6rem;
+  }
+  .post-body :global(li) {
+    margin-bottom: 0.4rem;
+  }
+  .post-body :global(li:last-child) {
+    margin-bottom: 0;
+  }
+  .post-body :global(li > ul),
+  .post-body :global(li > ol) {
+    margin-top: 0.4rem;
+  }
+  .post-body :global(li > ul) {
+    list-style-type: circle;
+  }
+  .post-body :global(li > ul ul) {
+    list-style-type: square;
+  }
   .post-footer {
     margin-top: var(--space-5);
     padding-top: var(--space-3);


### PR DESCRIPTION
## Problem
Markdown lists in post bodies have been rendering as plain indent-less paragraphs because Tailwind v4's Preflight resets \`list-style\` and \`padding-inline-start\` to zero on \`ul\` and \`ol\` globally. Visible on [/en/blog/mcp-considered-harmful/](https://yermilov.github.io/en/blog/mcp-considered-harmful/) — the three bullet items collapse into a flat paragraph stack — but the regression is sitewide. The project doesn't use \`@tailwindcss/typography\`, so prose elements need their own re-enable.

## Fix
Scoped CSS in \`PostLayout.astro\` that re-enables \`list-style\` inside \`.post-body\`:
- \`ul\` → \`disc outside\`, \`padding-inline-start: 1.4rem\`
- \`ol\` → \`decimal outside\`, \`padding-inline-start: 1.6rem\`
- \`li\` → \`margin-bottom: 0.4rem\` (zero on \`:last-child\`)
- nested \`ul\` walks through \`circle\` then \`square\` per the conventional prose default

## Test plan
- [x] \`pnpm --filter site typecheck\` clean (32 files, 0/0/0)
- [x] Visually verified \`/en/blog/mcp-considered-harmful/\` — three bullets render correctly under the intro paragraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)