### PR TITLE
Drop the books-index lede paragraph

### DIFF
--- a/apps/site/src/lib/i18n.ts
+++ b/apps/site/src/lib/i18n.ts
@@ -36,7 +36,6 @@ export interface Strings {
   empty: { blog: string; lab: string; games: string; talks: string; gallery: string; books: string };
   books: {
     indexTitle: string;
-    indexLede: string;
     backToBooks: string;
     by: string;
     rating: string;
@@ -107,7 +106,6 @@ const STRINGS: Record<Locale, Strings> = {
     },
     books: {
       indexTitle: 'Books',
-      indexLede: 'Books I’ve read — software engineering, leadership, fiction, the occasional weird gem. Newest first.',
       backToBooks: '← Back to books',
       by: 'by',
       rating: 'Rating',
@@ -168,7 +166,6 @@ const STRINGS: Record<Locale, Strings> = {
     },
     books: {
       indexTitle: 'Книги',
-      indexLede: 'Книги, які я прочитав — про інженерію, лідерство, художнє і всякі дивні знахідки. Спершу найновіші.',
       backToBooks: '← До книг',
       by: 'автор —',
       rating: 'Оцінка',

--- a/apps/site/src/pages/[locale]/books/index.astro
+++ b/apps/site/src/pages/[locale]/books/index.astro
@@ -14,12 +14,8 @@ const books = await getBooks();
 const yearFmt = new Intl.DateTimeFormat(bcp47Locale(locale), { year: 'numeric' });
 ---
 
-<BaseLayout locale={locale} title={strings.books.indexTitle} description={strings.books.indexLede} alternatePath="books">
+<BaseLayout locale={locale} title={strings.books.indexTitle} alternatePath="books">
   <section class="page-frame index">
-    <header class="prose-column">
-      <p class="lede">{strings.books.indexLede}</p>
-    </header>
-
     {books.length === 0 ? (
       <div class="prose-column">
         <p class="empty">{strings.empty.books}</p>


### PR DESCRIPTION
## Summary

- Remove the rendered `<p class="lede">` on `/books/` so the grid starts right under the header.
- Remove `strings.books.indexLede` from both EN and UA, and from the `Strings.books` interface.
- Drop the `description` prop on the books-index `BaseLayout` — it falls back to `strings.site.tagline`.

## Test plan

- [x] `pnpm --filter site typecheck` — 0 errors
- [x] `/en/books/` and `/ua/books/` render the book grid directly, no intro paragraph
- [x] No remaining references to `indexLede` in `apps/site/src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)