### PR TITLE
Add Rockstar Night 2019 meetup repeat of the JEEConf string-processing talk

### DIFF
--- a/apps/site/src/content/talks/string-processing-rockstar-night-2019.md
+++ b/apps/site/src/content/talks/string-processing-rockstar-night-2019.md
@@ -1,0 +1,13 @@
+---
+title: "String and Text Processing in Java on a Scale"
+event: "Rockstar Night: Modern Java World, Kyiv"
+eventUrl: "https://facebook.com/events/s/rockstar-night-modern-java-wor/825238474511567/"
+date: 2019-05-17
+abstract: "Co-presented with Kyrylo Holodnov. A meetup repeat of the JEEConf 2019 talk at iHUB on Khreshchatyk: what we learned running Java string processing at Grammarly's scale — Java 11's reworked String, JVM string hacks worth keeping, fast regexes, the perils of emoji, and what the true length of a Java string actually is once other services see it."
+slidesUrl: "https://www.slideshare.net/slideshow/string-and-text-processing-in-java-on-a-scale/145296175"
+tags:
+  - java
+  - performance
+  - jvm
+  - grammarly
+---


### PR DESCRIPTION
## Summary

- New talk entry: `apps/site/src/content/talks/string-processing-rockstar-night-2019.md`.
- Same talk content as the existing `string-processing-jeeconf-2019.md` (co-presented with Kyrylo Holodnov on Java string processing at Grammarly scale), delivered later the same evening at the Rockstar Night: Modern Java World meetup at iHUB on Khreshchatyk.
- Follows the existing one-file-per-event convention also used for the `it-scales-fwdays-2018` / `it-scales-devoxx-2018` pair.

## Test plan

- [x] `pnpm --filter site typecheck` — 0 errors
- [x] `/en/talks/` lists both String and Text Processing entries
- [x] `/en/talks/string-processing-rockstar-night-2019/` renders title, date, event link to Facebook, abstract

🤖 Generated with [Claude Code](https://claude.com/claude-code)