### PR TITLE
Fix JEEConf 2019 talk date: April 26, not May 17

### DIFF
--- a/apps/site/src/content/talks/string-processing-jeeconf-2019.md
+++ b/apps/site/src/content/talks/string-processing-jeeconf-2019.md
@@ -2,7 +2,7 @@
 title: "String and Text Processing in Java on a Scale"
 event: "JEEConf 2019, Kyiv"
 eventUrl: "https://jeeconf.com/program/string-and-text-processing-in-java-on-a-scale/"
-date: 2019-05-17
+date: 2019-04-26
 abstract: |
   Our Java applications handle millions of strings per second. We work with different platforms, including mobile. On a scale, even rare things happen. You can bet that eventually, an innocent text will crash your server… or the whole cluster. Over the years we have tried many performance tricks. Or should we call it premature optimizations?
 


### PR DESCRIPTION
## Summary

The JEEConf 2019 entry had `date: 2019-05-17`, which was actually the Rockstar Night meetup date. JEEConf 2019 ran April 26-27 in Kyiv (per dou.ua/calendar/25954/). Updated to `2019-04-26` (conference start); easy to flip to April 27 if the talk was on day two.

## Test plan

- [x] `pnpm --filter site typecheck` — 0 errors