### PR TITLE
Add It Scales 2018 KNU CS Faculty student talk

### DIFF
--- a/apps/site/src/content/talks/it-scales-knu-2018.md
+++ b/apps/site/src/content/talks/it-scales-knu-2018.md
@@ -1,0 +1,12 @@
+---
+title: "It Scales Until It Doesn't"
+event: "Chytalka @ KNU CS Faculty, Kyiv"
+eventUrl: "https://facebook.com/events/s/it-scales-until-it-doesnt/432525800611752/"
+date: 2018-11-14
+abstract: "Co-presented with Dmitry Tiagulskyi. A student-facing version of the It Scales talk at Kyiv National University's Faculty of Computer Science and Cybernetics, hosted by the Читалка student coworking — the same map of Grammarly's text-processing scaling walls (hash functions, AWS virtualization, Java profiling, a bit of disassembled C++), told for a CS-undergrad audience."
+slidesUrl: "https://www.slideshare.net/slideshow/dmitry-tiagulskyi-yaroslav-yermilov-it-scales-until-it-doesnt/116282023"
+tags:
+  - performance
+  - scaling
+  - grammarly
+---


### PR DESCRIPTION
## Summary

- Third occurrence of the It Scales Until It Doesn't talk: Nov 14, 2018 at Kyiv National University's Faculty of Computer Science and Cybernetics, hosted by Читалка (student coworking).
- Slots in between `it-scales-fwdays-2018.md` (Sep 15) and `it-scales-devoxx-2018.md` (Nov 23).
- Same `slidesUrl` and `tags` as the other two, short student-audience-focused abstract.

## Test plan

- [x] `pnpm --filter site typecheck` — 0 errors
- [x] `/en/talks/it-scales-knu-2018/` renders title, date Nov 14 2018, event link to Facebook, abstract